### PR TITLE
Split fuel UI

### DIFF
--- a/super_smash_bolt_ultimate/client/assets/sprites/swamp_objects/animated_swamp_objects_sprite_sheets/Giant Fly Sprite Sheet.png.import
+++ b/super_smash_bolt_ultimate/client/assets/sprites/swamp_objects/animated_swamp_objects_sprite_sheets/Giant Fly Sprite Sheet.png.import
@@ -3,15 +3,15 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://dwbvg2o0lcdl0"
-path="res://.godot/imported/Giant Fly Sprite Sheet.png-80713b06d7169d2892cf8f1738c197f6.ctex"
+path="res://.godot/imported/Giant Fly Sprite Sheet.png-e9066d862e4f219d277e07bebf548b9e.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://assets/sprites/animated_objects_sprite_sheets/Giant Fly Sprite Sheet.png"
-dest_files=["res://.godot/imported/Giant Fly Sprite Sheet.png-80713b06d7169d2892cf8f1738c197f6.ctex"]
+source_file="res://assets/sprites/swamp_objects/animated_swamp_objects_sprite_sheets/Giant Fly Sprite Sheet.png"
+dest_files=["res://.godot/imported/Giant Fly Sprite Sheet.png-e9066d862e4f219d277e07bebf548b9e.ctex"]
 
 [params]
 

--- a/super_smash_bolt_ultimate/client/scenes/UI.tscn
+++ b/super_smash_bolt_ultimate/client/scenes/UI.tscn
@@ -1,42 +1,36 @@
-[gd_scene load_steps=6 format=3 uid="uid://d2pc43vjhgr5w"]
+[gd_scene load_steps=7 format=3 uid="uid://d2pc43vjhgr5w"]
 
 [ext_resource type="Script" path="res://scripts/ui.gd" id="1_85aau"]
 [ext_resource type="Texture2D" uid="uid://cqtxofp8lb7j0" path="res://assets/sprites/battery-and-small-screen-ui-pixilart.png" id="1_b1rxw"]
 [ext_resource type="Texture2D" uid="uid://djlipafwkva7o" path="res://assets/sprites/yellow.png" id="2_vhlte"]
 [ext_resource type="Texture2D" uid="uid://cjauy8ip3076c" path="res://assets/sprites/green_power.tres" id="3_xgu5u"]
 
-[sub_resource type="GDScript" id="GDScript_gtps8"]
-script/source = "extends Sprite2D
+[sub_resource type="AtlasTexture" id="AtlasTexture_tg55b"]
+atlas = ExtResource("1_b1rxw")
+region = Rect2(26, 77, 51, 51)
 
-
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	pass # Replace with function body.
-
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
-	pass
-"
+[sub_resource type="AtlasTexture" id="AtlasTexture_bccij"]
+atlas = ExtResource("1_b1rxw")
+region = Rect2(21, 0, 55, 76)
 
 [node name="Ui" type="CanvasLayer"]
 script = ExtResource("1_85aau")
 
 [node name="boost_fuel" type="TextureProgressBar" parent="."]
 show_behind_parent = true
-offset_left = 37.0
+offset_left = 38.0
 offset_top = 529.0
-offset_right = 102.0
-offset_bottom = 621.0
+offset_right = 104.0
+offset_bottom = 622.0
 fill_mode = 3
 texture_progress = ExtResource("2_vhlte")
 
 [node name="power_fuel" type="TextureProgressBar" parent="."]
 show_behind_parent = true
-offset_left = 37.0
-offset_top = 528.0
-offset_right = 103.0
-offset_bottom = 621.0
+offset_left = 111.0
+offset_top = 529.0
+offset_right = 144.0
+offset_bottom = 622.0
 fill_mode = 3
 nine_patch_stretch = true
 texture_progress = ExtResource("3_xgu5u")
@@ -46,4 +40,13 @@ tint_progress = Color(0.182542, 0.625217, 0.228241, 1)
 position = Vector2(55, 609)
 scale = Vector2(1.4, 1.4)
 texture = ExtResource("1_b1rxw")
-script = SubResource("GDScript_gtps8")
+
+[node name="ui_base_extension" type="Sprite2D" parent="."]
+position = Vector2(117, 663)
+scale = Vector2(1.4, 1.4)
+texture = SubResource("AtlasTexture_tg55b")
+
+[node name="powerup_battery" type="Sprite2D" parent="."]
+position = Vector2(127, 573.4)
+scale = Vector2(0.736364, 1.43684)
+texture = SubResource("AtlasTexture_bccij")

--- a/super_smash_bolt_ultimate/client/scenes/UI.tscn
+++ b/super_smash_bolt_ultimate/client/scenes/UI.tscn
@@ -28,9 +28,9 @@ texture_progress = ExtResource("2_vhlte")
 [node name="power_fuel" type="TextureProgressBar" parent="."]
 show_behind_parent = true
 offset_left = 111.0
-offset_top = 529.0
+offset_top = 530.0
 offset_right = 144.0
-offset_bottom = 622.0
+offset_bottom = 623.0
 fill_mode = 3
 nine_patch_stretch = true
 texture_progress = ExtResource("3_xgu5u")
@@ -42,11 +42,13 @@ scale = Vector2(1.4, 1.4)
 texture = ExtResource("1_b1rxw")
 
 [node name="ui_base_extension" type="Sprite2D" parent="."]
+visible = false
 position = Vector2(117, 663)
 scale = Vector2(1.4, 1.4)
 texture = SubResource("AtlasTexture_tg55b")
 
 [node name="powerup_battery" type="Sprite2D" parent="."]
+visible = false
 position = Vector2(127, 573.4)
 scale = Vector2(0.736364, 1.43684)
 texture = SubResource("AtlasTexture_bccij")

--- a/super_smash_bolt_ultimate/client/scripts/ui.gd
+++ b/super_smash_bolt_ultimate/client/scripts/ui.gd
@@ -2,13 +2,10 @@ extends CanvasLayer
 var fuel
 var power_fuel
 
-# Called when the node enters the scene tree for the first time.
 func _ready():
 	fuel = get_node("boost_fuel")
 	power_fuel = get_node("power_fuel")
-	pass 
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
 	if power_fuel.value > 0:
 		$ui_base_extension.set_visible(true)
@@ -16,4 +13,3 @@ func _process(delta):
 	else:
 		$ui_base_extension.set_visible(false)
 		$powerup_battery.set_visible(false)
-	#pass

--- a/super_smash_bolt_ultimate/client/scripts/ui.gd
+++ b/super_smash_bolt_ultimate/client/scripts/ui.gd
@@ -10,8 +10,10 @@ func _ready():
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
-	if power_fuel.value > 0 and fuel.visible:
-		fuel.set_visible(false)
-	if power_fuel.value == 0 and !fuel.visible:
-		fuel.set_visible(true)
-	pass
+	if power_fuel.value > 0:
+		$ui_base_extension.set_visible(true)
+		$powerup_battery.set_visible(true)
+	else:
+		$ui_base_extension.set_visible(false)
+		$powerup_battery.set_visible(false)
+	#pass


### PR DESCRIPTION
Upon activating a powerup that uses fuel, the UI displays an extra battery to show how much fuel is left for the powerup, and the baseplate of the UI is extended. Normal dash fuel is still displayed in its regular battery. Once the powerup fuel source is depleted, the extra battery and extended UI base disappear. I'm not sure why the Giant Fly Sprite Sheet moved...