### PR TITLE
Fix SinglePlayer Bot Color + Breakable Wall Bug

### DIFF
--- a/super_smash_bolt_ultimate/client/main/user.gd
+++ b/super_smash_bolt_ultimate/client/main/user.gd
@@ -14,7 +14,7 @@ var game_scene_template = preload("res://scenes/game_scene.tscn")
 var player_character_template = preload("res://scenes/player_character.tscn")
 var spawn_positions : Dictionary = {}
 var is_spectator : bool = false
-var player_color = -1
+var player_color = 1
 
 var connection_list : Dictionary = {}
 var rtc_peer : WebRTCMultiplayerPeer

--- a/super_smash_bolt_ultimate/client/scenes/transient_wall.tscn
+++ b/super_smash_bolt_ultimate/client/scenes/transient_wall.tscn
@@ -86,5 +86,6 @@ shape = SubResource("RectangleShape2D_kytge")
 [connection signal="body_entered" from="RigidBodyUpperLeft" to="RigidBodyUpperLeft" method="_on_body_entered"]
 [connection signal="timeout" from="CRUMBLE" to="." method="_on_squeeeek_timeout"]
 [connection signal="area_entered" from="Area2DLeft" to="." method="_on_area_2d_area_entered"]
-[connection signal="body_entered" from="Area2DLeft" to="." method="_on_area_2d_body_entered"]
 [connection signal="body_entered" from="Area2DLeft" to="." method="_on_area_2d_left_body_entered"]
+[connection signal="body_entered" from="Area2DLeft" to="." method="_on_area_2d_body_entered"]
+[connection signal="body_exited" from="Area2DLeft" to="." method="_on_area_2d_left_body_exited"]

--- a/super_smash_bolt_ultimate/client/scripts/end_game_pop_up.gd
+++ b/super_smash_bolt_ultimate/client/scripts/end_game_pop_up.gd
@@ -20,7 +20,8 @@ var is_spectating = false
 func _ready() -> void:
 	setup()
 	$MarginContainer/VBoxContainer/BoxContainer/PlayAgain.grab_focus()
-	User.client.connect("player_died", player_died)
+	if !User.client.player_died.is_connected(player_died):
+		User.client.connect("player_died", player_died)
 
 func setup() -> void:
 	all_players = get_tree().get_nodes_in_group("Players")
@@ -50,6 +51,7 @@ func _on_play_again_pressed():
 		player_character.global_position = Vector2(0, -6)
 		player_character.get_node("Control/VBoxContainer/Control2").visible = false
 		get_tree().get_root().get_node("game_scene").add_child(player_character)
+		player_character.set_sprite(User.player_color)
 	else:
 		var pop_up = pop_up_template.instantiate()
 		pop_up.set_msg("   returning to lobby...")

--- a/super_smash_bolt_ultimate/client/scripts/main_menu.gd
+++ b/super_smash_bolt_ultimate/client/scripts/main_menu.gd
@@ -110,6 +110,7 @@ func _on_color_changer_pressed() -> void:
 	if bot_color > 8:
 		bot_color = 1
 	$Background/AnimatedBot.set_color(bot_color)
+	User.player_color = bot_color
 
 func _on_singleplayer_pressed():
 	var peer = OfflineMultiplayerPeer.new()

--- a/super_smash_bolt_ultimate/client/scripts/main_menu.gd
+++ b/super_smash_bolt_ultimate/client/scripts/main_menu.gd
@@ -13,6 +13,9 @@ var bot_color = 1
 
 func _ready() -> void:
 	name = "main_menu"
+	$Background/AnimatedBot/AnimationTree.get("parameters/playback").travel("fall_end")
+	$Background/AnimatedBot.set_color(User.player_color)
+	bot_color = User.player_color
 
 func go_to_lobby_menu():
 	User.after_main_menu_init()

--- a/super_smash_bolt_ultimate/client/scripts/pause_menu.gd
+++ b/super_smash_bolt_ultimate/client/scripts/pause_menu.gd
@@ -29,8 +29,9 @@ func _on_continue_pressed():
 
 func _on_restart_pressed():
 	self.reparent(get_tree().get_root())
-	if get_tree().get_root().get_node("game_scene"):
-		get_tree().get_root().get_node("game_scene").free()
+	var game_scene_node = get_tree().get_root().get_node_or_null("game_scene")
+	if game_scene_node:
+		game_scene_node.free()
 		User.current_lobby_seed = RandomNumberGenerator.new().randi()
 		var game_scene = load("res://scenes/game_scene.tscn").instantiate()
 		game_scene.set_multiplayer_authority(User.ID)
@@ -42,7 +43,8 @@ func _on_restart_pressed():
 		player_character.global_position = Vector2(0, -6)
 		player_character.get_node("Control/VBoxContainer/Control2").visible = false
 		get_tree().get_root().get_node("game_scene").add_child(player_character)
-	
+		player_character.set_sprite(User.player_color)
+		
 	else:
 		#get_tree().get_root().get_node("tutorial").free()
 		#var game_scene = load("res://scenes/tutorial.tscn").instantiate()
@@ -54,9 +56,9 @@ func _on_restart_pressed():
 	queue_free()
 
 func _on_quit_pressed():
-	var game_scene_node = get_tree().get_root().get_node("game_scene")
+	var game_scene_node = get_tree().get_root().get_node_or_null("game_scene")
 	var main_node = get_tree().get_root().get_node("main")
-	if get_tree().get_root().get_node("game_scene") == null:
+	if !game_scene_node:
 		game_scene_node = get_tree().get_root().get_node("tutorial")
 	if User.ID == MultiplayerPeer.TARGET_PEER_SERVER:
 		self.reparent(get_tree().get_root())

--- a/super_smash_bolt_ultimate/client/scripts/transient_wall.gd
+++ b/super_smash_bolt_ultimate/client/scripts/transient_wall.gd
@@ -10,13 +10,24 @@ const MAX_TIMER_ITERATION   = 9
 const IDEAL_TIMER_ITERATION = 3
 
 var   timer_iteration       = 1 #Humans never count from zero!
+var   is_body_in_area          = false
+var   body_in_area
 
 @onready var gracious_delay: Timer = $CRUMBLE
 
+func _process(delta: float) -> void:
+	if is_body_in_area and body_in_area.isDashing:
+		crumblings()
+		
 
 func _on_area_2d_left_body_entered(body: Node2D) -> void:
-	if(body.get_class() == "CharacterBody2D" and body.isDashing == true):
-		crumblings()
+	if body.get_class() == "CharacterBody2D": 
+		is_body_in_area = true
+		body_in_area = body
+		if body.isDashing:
+			crumblings()
+			
+
 
 func crumblings():
 	$SolidBlock.queue_free()
@@ -49,3 +60,7 @@ func _on_squeeeek_timeout() -> void:
 @rpc("any_peer", "call_remote")
 func synchronized_crumblings():
 	crumblings()
+
+
+func _on_area_2d_left_body_exited(body: Node2D) -> void:
+	is_body_in_area = false

--- a/super_smash_bolt_ultimate/client/scripts/transient_wall.gd
+++ b/super_smash_bolt_ultimate/client/scripts/transient_wall.gd
@@ -16,7 +16,7 @@ var   body_in_area
 @onready var gracious_delay: Timer = $CRUMBLE
 
 func _process(delta: float) -> void:
-	if is_body_in_area and body_in_area.isDashing:
+	if is_body_in_area and (body_in_area.isDashing or body_in_area.isPowerUpDashing):
 		crumblings()
 		
 
@@ -24,7 +24,7 @@ func _on_area_2d_left_body_entered(body: Node2D) -> void:
 	if body.get_class() == "CharacterBody2D": 
 		is_body_in_area = true
 		body_in_area = body
-		if body.isDashing:
+		if body.isDashing or body.isPowerUpDashing:
 			crumblings()
 			
 

--- a/super_smash_bolt_ultimate/client/scripts/tutorial_player_character.gd
+++ b/super_smash_bolt_ultimate/client/scripts/tutorial_player_character.gd
@@ -47,7 +47,7 @@ var pause_menu_template = preload("res://scenes/pause_menu.tscn")
 @onready var oilSpillTimer: Timer = $Timers/OilSpillTimer
 @onready var stunTimer:Timer = $Timers/StunTimer
 @onready var hitFlashAnimationPlayer = $HitFlashAnimationPlayer
-##@onready var displacement_hud = $Label
+#@onready var displacement_hud = $Label
 #@onready var displacementUpdateTimer: Timer = $Timers/DisplacementUpdateTimer
 @onready var death_explosion = preload("res://scenes/death_explosion.tscn")
 @onready var player_spawn_x = position.x
@@ -77,7 +77,7 @@ var attack_timer : int = 0
 @onready var original_anim_tree = $AnimationTree
 @onready var anim_tree = $AnimationTree.get("parameters/playback")
 @onready var anim_player = $AnimationPlayer
-@onready var character_name = $Control/VBoxContainer/Control2/Label
+#@onready var character_name = $Control/VBoxContainer/Control2/Label
 
 func _ready():
 	reset()
@@ -412,7 +412,7 @@ func stun_timer_timeout():
 @rpc("any_peer","call_remote","reliable")
 func set_player_name(_name : String):
 	print("Here is the name: %s" % _name)
-	character_name.text = _name
+	#character_name.text = _name
 
 @rpc("any_peer","call_local","reliable")
 func set_sprite(player_color):


### PR DESCRIPTION
- Fix Bug Where Singleplayer Bot Color was reset when user clicks play again or restart
- Allows For Breakable Wall To Be Broken Even After Initial "Area Entered"
- Some Node Null Reference Updates